### PR TITLE
Specify torch and torchvision requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-torch
-torchvision
+torch<=1.6.0
+torchvision<=0.7.0
 graphviz
 matplotlib
 scipy


### PR DESCRIPTION
The code fails on newer versions of torch due to this error: https://github.com/pytorch/examples/issues/836

Specifying a maximum version number for torch and torchvision will prevent people from running into this issue.